### PR TITLE
Revert to 0.66.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifications",
   "main": "./lib/main",
-  "version": "0.66.2",
+  "version": "0.66.1",
   "description": "A tidy way to display Atom notifications.",
   "repository": "https://github.com/atom/notifications",
   "license": "MIT",

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -204,15 +204,8 @@ atom-notification {
     }
   }
 
-  .btn-toolbar.btn-toolbar {
-    margin-top: 10px;
-    margin-bottom: -5px;
-    margin-left: 0;
-  }
-
-  .btn-toolbar.btn-toolbar > .btn {
-    margin-left: 0;
-    margin-bottom: 5px;
+  .btn-toolbar {
+    margin-top:  @component-padding;
   }
 
   .btn-copy-report {


### PR DESCRIPTION
The [learn-ide](https://github.com/learn-co/learn-ide) currently runs on [atom@1.14.4](https://github.com/atom/atom/releases/v1.14.4), which uses [notifications@v0.66.1](https://github.com/atom/notifications/releases/v0.66.1).

This makes all of that work as it should.