### PR TITLE
Rename to learn-ide-notifications and change default issue repo

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -158,14 +158,14 @@ class NotificationElement extends HTMLElement
       issueButton.remove()
       fatalNotification.textContent = "The error was thrown from the #{packageName} package. "
     else
-      fatalNotification.textContent = "This is likely a bug in Atom. "
+      fatalNotification.textContent = "This is likely a bug in the Learn IDE. "
 
     # We only show the create issue button if it's clearly in atom core or in a package with a repo url
     if issueButton.parentNode?
       if packageName? and repoUrl?
         issueButton.textContent = "Create issue on the #{packageName} package"
       else
-        issueButton.textContent = "Create issue on atom/atom"
+        issueButton.textContent = "Create issue on learn-co/learn-ide"
 
       promises = []
       promises.push @issue.findSimilarIssues()

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -20,7 +20,7 @@ class NotificationIssue
 
   findSimilarIssues: ->
     repoUrl = @getRepoUrl()
-    repoUrl = 'atom/atom' unless repoUrl?
+    repoUrl = 'learn-co/learn-ide' unless repoUrl?
     repo = repoUrl.replace /http(s)?:\/\/(\d+\.)?github.com\//gi, ''
     issueTitle = @getIssueTitle()
     query = "#{issueTitle} repo:#{repo}"
@@ -54,7 +54,7 @@ class NotificationIssue
   getIssueUrl: ->
     @getIssueBody().then (issueBody) =>
       repoUrl = @getRepoUrl()
-      repoUrl = 'https://github.com/atom/atom' unless repoUrl?
+      repoUrl = 'https://github.com/learn-co/learn-ide' unless repoUrl?
       "#{repoUrl}/issues/new?title=#{@encodeURI(@getIssueTitle())}&body=#{@encodeURI(issueBody)}"
 
   encodeURI: (str) ->
@@ -102,12 +102,13 @@ class NotificationIssue
           packageMessage = 'Atom Core'
 
         @issueBody = """
-          [Enter steps to reproduce:]
+          [Before submitting, please enter steps to reproduce:]
 
           1. ...
           2. ...
 
-          **Atom**: #{atom.getVersion()} #{process.arch}
+          **Learn IDE Package**: #{LEARN_IDE_VERSION}
+          **Learn IDE Core**: #{atom.getVersion()} #{process.arch}
           **Electron**: #{process.versions.electron}
           **OS**: #{systemName}
           **Thrown From**: #{packageMessage}

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -108,14 +108,18 @@ module.exports =
       devPackageNames = atom.packages.getAvailablePackagePaths().filter((p) -> p.includes(DEV_PACKAGE_PATH)).map((p) -> path.basename(p))
       resolve("#{pack.name} #{pack.version} #{if pack.name in devPackageNames then '(dev)' else ''}" for pack in nonCorePackages)
 
-  getLatestAtomData: ->
-    fetch 'https://atom.io/api/updates', {headers: githubHeaders}
-      .then (r) -> if r.ok then r.json() else Promise.reject r.statusCode
+  getLatestLearnIDEData: ->
+    fetch('https://learn.co/api/v1/learn_ide/latest_version')
+      .then (r) -> if r.ok then r.json() else Promise.reject(r.statusCode)
+
+  currentLearnIDEVersion: ->
+    pkg = atom.packages.loadPackage('learn-ide')
+    pkg?.metadata.version
 
   checkAtomUpToDate: ->
-    @getLatestAtomData().then (latestAtomData) ->
-      installedVersion = atom.getVersion()?.replace(/-.*$/, '')
-      latestVersion = latestAtomData.name
+    @getLatestLearnIDEData().then ({version}) =>
+      installedVersion = @currentLearnIDEVersion()
+      latestVersion = version
       upToDate = installedVersion? and semver.gte(installedVersion, latestVersion)
       {upToDate, latestVersion, installedVersion}
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "notifications",
+  "name": "learn-ide-notifications",
   "main": "./lib/main",
   "version": "0.66.1",
-  "description": "A tidy way to display Atom notifications.",
-  "repository": "https://github.com/atom/notifications",
+  "description": "A tidy fork of atom/notifications used by the Learn IDE",
+  "repository": "https://github.com/learn-co/learn-ide-notifications",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"


### PR DESCRIPTION
part of https://github.com/learn-co/learn-ide/issues/416

### TODO
- [x] test exception reporting (i.e. issues are opened on `learn-ide`)
- [ ] (after merge) add "upstreamVersion" key to package.json, with value "0.66.1"
- [ ] (after merge) prep & release @v0.66.3 (one patch ahead of upstream's latest)